### PR TITLE
Support POST requests

### DIFF
--- a/lib/snowly/app/collector.rb
+++ b/lib/snowly/app/collector.rb
@@ -23,10 +23,11 @@ module Snowly
 
       get '/i' do
         content_type :json
-        validator = Snowly::Validator.new request.query_string
+        request_payload = (Snowly::Request.new request.query_string).as_hash
+        validator = Snowly::Validator.new request_payload
         if validator.validate
           status 200
-          content = { content: validator.request.as_hash }.to_json
+          content = { content: request_payload }.to_json
           Snowly.logger.info content
           if params[:debug] || Snowly.debug_mode
             body(content)
@@ -36,7 +37,7 @@ module Snowly
           end
         else
           status 500
-          content = { errors: validator.errors, content: validator.request.as_hash }.to_json
+          content = { errors: validator.errors, content: request_payload }.to_json
           Snowly.logger.error content
           body (content)
         end

--- a/lib/snowly/validator.rb
+++ b/lib/snowly/validator.rb
@@ -8,8 +8,8 @@ module Snowly
 
     attr_reader :request, :errors, :protocol_schema
 
-    def initialize(query_string)
-      @request = Request.new query_string
+    def initialize(request_payload)
+      @request_payload = request_payload
       @errors = []
       @protocol_schema = load_protocol_schema
     end
@@ -53,12 +53,12 @@ module Snowly
 
     # @return [Hash] all contexts content and schema definitions
     def associated_contexts
-      load_contexts request.as_hash['contexts']
+      load_contexts @request_payload['contexts']
     end
 
     # @return [Hash] all unstructured events content and schema definitions
     def associated_unstruct_event
-      load_unstruct_event request.as_hash['unstruct_event']
+      load_unstruct_event @request_payload['unstruct_event']
     end
 
     # @return [Array<Hash>] all associated content
@@ -110,7 +110,7 @@ module Snowly
 
     # Validates root attributes for the events table
     def validate_root
-      this_error = JSON::Validator.fully_validate protocol_schema, request.as_hash
+      this_error = JSON::Validator.fully_validate protocol_schema, @request_payload
       @errors += this_error if this_error.count > 0
     end
   end


### PR DESCRIPTION
We really want to use snowly to validate our tracking requests against schemas.
Our API is already POSTing to the collector, and we plan to upgrade the front-end library as well to use POST.

We had 2 challenges implementing POST support:
1. Snowly must support CORS preflight requests to support POST requests originating from a web page.
2. POST requests can contain multiple events, all of them has to be validated, and the errors have to belong to certain events.
